### PR TITLE
bugfix: Exclude import match should continue, not exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 					}
 
 					if mustExclude(excludeImportRegexps, importPath) {
-						return nil
+						continue
 					}
 
 					parts := strings.Split(importPath, "/")


### PR DESCRIPTION
Exclude import match should skip import check not file check.